### PR TITLE
OpenAPI: Change query param and add tag to please the validator

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,11 +32,16 @@ paths:
           in: query
           explode: true
           description: |
-            Search query. To get the disjunct result set of multiple queries, specify the parameter multiple times.
-            This is to support drill-down search.
+            Search query to support drill-down search.
+            Can be specified multiple times as a union.
+            It accepts a JSON-encoded query object.
           required: false
           schema:
-            $ref: '#/components/schemas/Query'
+            type: array
+            items:
+              type: string
+            example:
+              - '{"genre": {"eq": "Dubstep"}, "bpm": {"lt": "90"}}'
       responses:
         '200':
           description: Supported attribute value range
@@ -53,10 +58,16 @@ paths:
           in: query
           explode: true
           description: |
-            Search query. Can be specified multiple times as a disjunction.
+            Search query.
+            Can be specified multiple times as a union.
+            It accepts a JSON-encoded query object.
           required: false
           schema:
-            $ref: '#/components/schemas/Query'
+            type: array
+            items:
+              type: string
+            example:
+              - '{"genre": {"eq": "Dubstep"}, "bpm": {"lt": "90"}}'
       responses:
         '200':
           description: Search result

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,15 +1,32 @@
-openapi: "3.0.0"
+openapi: "3.0.1"
 info:
   title: Song search and playlist generator API
+  description: Song search and playlist generator API
   version: 1.0.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Max Goltzsche
+    url: https://github.com/mgoltzsche/beets-websearch
+    email: max.goltzsche@gmail.com
+
+servers:
+  - url: /
+
+tags:
+  - name: websearch
+
 paths:
   /attributes:
     get:
       operationId: attributes
-      summary: Lists attributes that can be used as search criteria (frontend can generate search form based on this data).
+      summary: Lists attribute definitions
+      description: |
+        Lists attributes that can be used as search criteria.
+        (The frontend could generate a search form based on this data.)
+      tags:
+        - websearch
       responses:
         '200':
           description: Attribute definitions
@@ -20,7 +37,11 @@ paths:
   /attributes/{attribute}/info:
     get:
       operationId: getAttributeInfo
-      summary: Get the supported attribute value range
+      summary: Get the attribute value range
+      description: |
+        Provides the range of values for a given attribute definition and search query.
+      tags:
+        - websearch
       parameters:
         - name: attribute
           in: path
@@ -53,6 +74,9 @@ paths:
     get:
       operationId: listTracks
       summary: List/search tracks
+      description: List and search tracks.
+      tags:
+        - websearch
       parameters:
         - name: query
           in: query
@@ -79,6 +103,9 @@ paths:
     get:
       operationId: listPlaylists
       summary: List playlists
+      description: List all playlists.
+      tags:
+        - websearch
       responses:
         '200':
           description: List of playlists
@@ -89,6 +116,9 @@ paths:
     post:
       operationId: createPlaylist
       summary: Create playlist
+      description: Create a new playlist based on the given set of song queries.
+      tags:
+        - websearch
       requestBody:
         description: Playlist that should be created
         required: true
@@ -106,6 +136,9 @@ paths:
     put:
       operationId: updatePlaylist
       summary: Update playlist
+      description: Update an existing playlist.
+      tags:
+        - websearch
       requestBody:
         description: Playlist that should be updated
         required: true
@@ -124,6 +157,9 @@ paths:
     delete:
       operationId: deletePlaylist
       summary: Delete playlist
+      description: Delete a playlist.
+      tags:
+        - websearch
       parameters:
         - name: playlist
           in: path
@@ -269,10 +305,10 @@ components:
       required:
         - name
       example:
-        name: last 7 days
+        name: Slow/dark Dubstep
         created: "2024-07-14T16:16:16Z"
         query:
-          - added- added:-7d..
+          - {"genre": {"eq": "Dubstep"}, "bpm": {"lt": "90"}}
     Query:
       type: array
       items:
@@ -280,7 +316,7 @@ components:
         additionalProperties:
           $ref: '#/components/schemas/Operation'
       example:
-        - {"genre": {"eq": "Dub"}, "bpm": {"lt": "105"}}
+        - {"genre": {"eq": "Dubstep"}, "bpm": {"lt": "90"}}
         - {"genre": {"eq": "Grime"}, "bpm": {"lt": "105"}}
     Operation:
       type: object


### PR DESCRIPTION
* [BREAKING API CHANGE] Change the type of the `query` query parameter from `object` to `string`.
This is because the `python-fastapi` generator doesn't support query parameters of type `object`.
Instead, the parameter value has to be JSON-decoded by the manually written code / as part of the business logic.
(While OpenAPI 2 does not support query parameters of type object, OpenAPI 3 does support them.
However, in practice many generators are still not supporting it because they don't know how to deserialize the object from the query string.)
* [BREAKING generate CHANGE] Add `websearch` tag to every endpoint in order to have more expressive identifiers within the generated code: `default` becomes `websearch` within the generate. Also, the validator complained about the missing tag previously.
* Specify descriptions and server that were previously missing which the spectral OpenAPI validator complained about.
* Fix a query example that was invalid (which the validator detected).

I validated the OpenAPI changes using `make validate-openapi` (which uses [`@stoplight/spectral-cli`](https://www.npmjs.com/package/@stoplight/spectral-cli) which required me to make most of the changes in the first place).