### PR TITLE
fix(openapi): fix additionalProperties definition

### DIFF
--- a/beetsplug/websearch/controller/__init__.py
+++ b/beetsplug/websearch/controller/__init__.py
@@ -99,11 +99,8 @@ class WebsearchApi(BaseWebsearchApi):
                 Track(
                     id="123",
                     title="Serpiente Dorada",
-                    # TODO: make this work (generated code expects a string currently):
-                    #additional_properties={
-                    #    "genre": "Dub",
-                    #    "bpm": "90",
-                    #},
+                    genre=str("Dub"),
+                    bpm=str("90"),
                 ),
             ],
         )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -189,8 +189,8 @@ components:
           type: string
         title:
           type: string
-        additionalProperties:
-          type: string
+      additionalProperties:
+        type: string
       required:
         - id
         - title


### PR DESCRIPTION
Previously additionalProperties were indented wrongly so that they appeared as a regular property.

Also, adjust the controller code correspondingly.

Depends on the openapi-generator PR https://github.com/OpenAPITools/openapi-generator/pull/19312 (otherwise additionalProperties support does not work with the python-fastapi generator)