### PR TITLE
Add m3u provider api

### DIFF
--- a/beetsplug/websearch/__init__.py
+++ b/beetsplug/websearch/__init__.py
@@ -3,7 +3,7 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from optparse import OptionParser
 from beetsplug.web import ReverseProxied
-from beetsplug.websearch.webapp import create_app, configure_app
+from beetsplug.websearch.app import create_app, configure_app
 
 
 class WebSearchPlugin(BeetsPlugin):

--- a/beetsplug/websearch/app.py
+++ b/beetsplug/websearch/app.py
@@ -3,32 +3,36 @@ import beetsplug.websearch.controller as ctrl
 
 from beets import config
 from typing import Any, Optional, Union
-from fastapi import FastAPI
+from fastapi import FastAPI, Path, Request
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
 
 from beetsplug.websearch.state.jsonfile import JSONFileRepository
+from beetsplug.websearch.sendfile import sendfile
+from beetsplug.websearch.m3uprovider import router as M3UProviderRouter
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     state_dir = config['websearch']['state_dir'].get()
     playlists_file = os.path.join(state_dir, "playlists.json")
+    playlists_repo = JSONFileRepository(playlists_file)
     ctrl.lib = app.state.lib
-    ctrl.playlists = JSONFileRepository(playlists_file)
+    ctrl.playlists = playlists_repo
     yield
 
 
 def create_app():
     app = FastAPI(
-        title="Song search and playlist management API",
-        description="Song search and playlist management API",
+        title="Playlist composer API",
+        description="Playlist composer and M3U provider API",
         version="1.0.0",
         lifespan=lifespan,
     )
 
-    from beetsplug.websearch.gen.apis.websearch_api import router as WebsearchApiRouter
+    from beetsplug.websearch.gen.apis.composer_api import router as WebsearchApiRouter
 
     app.include_router(WebsearchApiRouter)
+    app.include_router(M3UProviderRouter)
 
     return app
 

--- a/beetsplug/websearch/m3uprovider/__init__.py
+++ b/beetsplug/websearch/m3uprovider/__init__.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+from typing import Dict, List  # noqa: F401
+import importlib
+import pkgutil
+
+from fastapi import (  # noqa: F401
+    APIRouter,
+    Body,
+    Cookie,
+    Depends,
+    Form,
+    Header,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    Security,
+    status,
+)
+from fastapi.responses import StreamingResponse
+from beetsplug.websearch.sendfile import sendfile
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/tracks/{id}/audio",
+    responses={
+        200: {},
+    },
+    tags=["provider"],
+    summary="Get audio data for the given track ID",
+    response_model_by_alias=True,
+)
+async def get_audio_data(
+    request: Request,
+    id: str = Path(..., description="Beets item ID"),
+) -> StreamingResponse:
+    """Get/stream audio data for the given track ID."""
+    item = request.app.state.lib.get_item(id)
+    if not item:
+        raise KeyError(f"item {id} not found")
+    filepath = item.path.decode('utf-8')
+    return sendfile(filepath, request.headers.get('range'))
+
+
+@router.get(
+    "/playlists.m3u",
+    responses={
+        200: {"model": str, "description": "Index playlist in EXTM3U format"},
+    },
+    tags=["provider"],
+    summary="Get index EXTM3U playlist that lists all playlists",
+    response_model_by_alias=True,
+)
+async def get_m3_u_index(
+) -> str:
+    """Get the index playlist that contains URLs pointing to the actual playlists."""
+    raise HTTPException(status_code=500, detail="Not implemented")
+
+
+@router.get(
+    "/playlists/{playlistId}/tracks.m3u",
+    responses={
+        200: {"model": str, "description": "Playlist tracks in EXTM3U format"},
+    },
+    tags=["provider"],
+    summary="Get playlist tracks in EXTM3U format",
+    response_model_by_alias=True,
+)
+async def get_m3_u_playlist(
+    playlistId: str = Path(..., description="Playlist ID"),
+) -> str:
+    """Get the tracks contained within a playlist in the EXTM3U format."""
+    raise HTTPException(status_code=500, detail="Not implemented")

--- a/beetsplug/websearch/sendfile.py
+++ b/beetsplug/websearch/sendfile.py
@@ -1,0 +1,110 @@
+from fastapi.responses import StreamingResponse
+import logging
+import mimetypes
+from pathlib import Path
+import posixpath
+from typing import IO, Generator
+
+"""
+Stream a file with FastAPI and range request support.
+Based on https://gist.github.com/tombulled/712fd8e19ed0618c5f9f7d5f5f543782
+"""
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MIME_TYPE = 'application/octet-stream'
+EXTENSION_TO_MIME_TYPE_FALLBACK = {
+    '.aac'  : 'audio/aac',
+    '.flac' : 'audio/flac',
+    '.mp3'  : 'audio/mpeg',
+    '.mp4'  : 'audio/mp4',
+    '.m4a'  : 'audio/mp4',
+    '.ogg'  : 'audio/ogg',
+    '.opus' : 'audio/opus',
+}
+
+def path_to_content_type(path: str):
+    result = mimetypes.guess_type(path)[0]
+    if result:
+        return result
+
+    base, ext = posixpath.splitext(path)
+    result = EXTENSION_TO_MIME_TYPE_FALLBACK.get(ext)
+
+    if result:
+        return result
+
+    logger.warning(f"No mime type mapped for {ext} extension: {path}")
+
+    return DEFAULT_MIME_TYPE
+
+def sendfile(filepath: str, content_range: str) -> StreamingResponse:
+    path = Path(filepath)
+
+    # TODO: close file after response was sent
+    file = path.open('rb')
+
+    file_size = path.stat().st_size
+
+    content_length = file_size
+    status_code = 200
+    headers = {}
+
+    if content_range is not None:
+        content_range = content_range.strip().lower()
+
+        content_ranges = content_range.split('=')[-1]
+
+        range_start, range_end, *_ = map(str.strip, (content_ranges + '-').split('-'))
+
+        range_start = max(0, int(range_start)) if range_start else 0
+        range_end   = min(file_size - 1, int(range_end)) if range_end else file_size - 1
+
+        content_length = (range_end - range_start) + 1
+
+        file = _ranged(file, start = range_start, end = range_end + 1)
+
+        status_code = 206
+
+        headers['Content-Range'] = f'bytes {range_start}-{range_end}/{file_size}'
+
+    response = StreamingResponse(file,
+        media_type = path_to_content_type(filepath),
+        status_code = status_code,
+    )
+
+    response.headers.update({
+        'Accept-Ranges': 'bytes',
+        'Content-Length': str(content_length),
+        **headers,
+    })
+
+    return response
+
+def _ranged(file: IO[bytes],
+            start: int = 0,
+            end: int = None,
+            block_size: int = 8192,
+        ) -> Generator[bytes, None, None]:
+    consumed = 0
+
+    try:
+        file.seek(start)
+    
+        while True:
+            data_length = min(block_size, end - start - consumed) if end else block_size
+    
+            if data_length <= 0:
+                break
+    
+            data = file.read(data_length)
+    
+            if not data:
+                break
+    
+            consumed += data_length
+    
+            yield data
+    finally:
+        if hasattr(file, 'close'):
+            file.close()

--- a/openapi/composer.yaml
+++ b/openapi/composer.yaml
@@ -14,7 +14,7 @@ servers:
   - url: /
 
 tags:
-  - name: websearch
+  - name: composer
 
 paths:
   /attributes:
@@ -25,7 +25,7 @@ paths:
         Lists attributes that can be used as search criteria.
         (The frontend could generate a search form based on this data.)
       tags:
-        - websearch
+        - composer
       responses:
         '200':
           description: Attribute definitions
@@ -40,7 +40,7 @@ paths:
       description: |
         Provides the range of available values for a given attribute definition and search query.
       tags:
-        - websearch
+        - composer
       parameters:
         - name: attribute
           in: path
@@ -70,7 +70,7 @@ paths:
       summary: List/search tracks
       description: List and search tracks.
       tags:
-        - websearch
+        - composer
       parameters:
         - name: query
           in: query
@@ -94,7 +94,7 @@ paths:
       summary: List playlists
       description: List all playlists.
       tags:
-        - websearch
+        - composer
       responses:
         '200':
           description: List of playlists
@@ -111,11 +111,11 @@ paths:
         schema:
           type: string
     put:
-      operationId: upsertPlaylist
+      operationId: savePlaylist
       summary: Create or update playlist
       description: Create or update a playlist.
       tags:
-        - websearch
+        - composer
       requestBody:
         description: Playlist that should be created/updated
         required: true
@@ -135,7 +135,7 @@ paths:
       summary: Delete playlist
       description: Delete a playlist.
       tags:
-        - websearch
+        - composer
       responses:
         '204':
           description: Playlist deleted
@@ -145,7 +145,7 @@ paths:
       summary: Get playlist tracks
       description: Get the tracks contained within a playlist.
       tags:
-        - websearch
+        - composer
       parameters:
         - name: playlistId
           in: path
@@ -160,6 +160,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackList'
+
 
 components:
   schemas:
@@ -179,16 +180,26 @@ components:
           type: string
         title:
           type: string
+        artist:
+          type: string
+        album:
+          type: string
+        audioUrl:
+          type: string
+          description: URL pointing to the audio stream provided by the provider API
       additionalProperties:
         type: string
       required:
         - id
+        - artist
         - title
+        - audioUrl
       example:
-        id: "123"
+        id: '123'
         artist: Dengue Dengue Dengue
         title: Serpiente Dorada
-        bpm: "70"
+        bpm: '70'
+        audioUrl: 'http://localhost:5000/api/v1/tracks/123/audio'
     AttributeDefinitionList:
       type: object
       properties:
@@ -298,18 +309,19 @@ components:
           example: "2024-07-14T16:16:16Z"
         query:
           $ref: '#/components/schemas/Query'
-        url:
+        m3uUrl:
           type: string
-          example: 'http://localhost:5000/m3u/playlists/jazz/playlist.m3u'
+          description: URL pointing to the M3U playlist provided by the provider API
       required:
         - id
         - title
       example:
-        id: slow-dubstep.m3u
+        id: slow-dubstep
         title: Slow/dark Dubstep
         created: "2024-07-14T16:16:16Z"
         query:
           - {"genre": {"eq": "Dubstep"}, "bpm": {"lt": "90"}}
+        m3uUrl: 'http://localhost:5000/api/v1/playlists/slow-dubstep/tracks.m3u'
     Query:
       type: array
       items:

--- a/openapi/provider.yaml
+++ b/openapi/provider.yaml
@@ -1,0 +1,88 @@
+openapi: "3.0.1"
+info:
+  title: M3U Playlist Provider
+  description: M3U playlist and audio stream provider API.
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    name: Max Goltzsche
+    url: https://github.com/mgoltzsche/beets-websearch
+
+servers:
+  - url: /
+
+tags:
+  - name: provider
+
+paths:
+  /playlists.m3u:
+    get:
+      operationId: getM3UIndex
+      summary: Get index EXTM3U playlist that lists all playlists
+      description: Get the index playlist that contains URLs pointing to the actual playlists.
+      tags:
+        - provider
+      responses:
+        '200':
+          description: Index playlist in EXTM3U format
+          content:
+            application/x-mpegurl:
+              schema:
+                type: string
+                example: |
+                  #EXTM3U
+                  #EXTINF:0,Playlist 1
+                  http://localhost:5000/playlists/playlist1.m3u
+                  #EXTINF:0,Playlist 2
+                  http://localhost:5000/playlists/playlist2.m3u
+  /playlists/{playlistId}.m3u:
+    get:
+      operationId: getM3UPlaylist
+      summary: Get playlist tracks in EXTM3U format
+      description: Get the tracks contained within a playlist in the EXTM3U format.
+      tags:
+        - provider
+      parameters:
+        - name: playlistId
+          in: path
+          description: Playlist ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Playlist tracks in EXTM3U format
+          content:
+            application/x-mpegurl:
+              schema:
+                type: string
+                example: |
+                  #EXTM3U
+                  #EXTINF:0,Track 1
+                  http://localhost:5000/tracks/1/audio
+                  #EXTINF:0,Track 2
+                  http://localhost:5000/tracks/2/audio
+  /tracks/{id}/audio:
+    get:
+      operationId: getAudioData
+      summary: Get audio data for the given track ID
+      description: Get/stream audio data for the given track ID.
+      tags:
+        - provider
+      parameters:
+        - name: id
+          in: path
+          description: Beets item ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Audio data
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary


### PR DESCRIPTION
* Rename the `websearch` tag within the openapi to `composer`.
* Specify audio/M3U `provider` API within a separate OpenAPI file.
  This is because client generators shouldn't have to generate code to access the streaming endpoint but use the URLs the JSON API returns to feed them into other tools/libraries. Also, python-fastapi generator produces invalid output when given a binary response as required for the audio streaming endpoint.
* Move the OpenAPI files into the new `./openapi` directory.
* Implement audio stream endpoint and OpenAPI changes.

![grafik](https://github.com/user-attachments/assets/29fc5c20-a1ad-411f-9f13-4c87f4c2950e)
